### PR TITLE
Allow cert manager to use namespaces.

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -32,10 +32,11 @@ type dnsClient struct {
 	provider  string
 	secret    string
 	secretKey string
+	namespace string
 }
 
-func newDNSClient(provider, domain, secret, secretKey string) (*dnsClient, error) {
-	return &dnsClient{domain, provider, secret, secretKey}, nil
+func newDNSClient(provider, domain, secret, secretKey, namespace string) (*dnsClient, error) {
+	return &dnsClient{domain, provider, secret, secretKey, namespace}, nil
 }
 
 func envVar(key, value string) string {
@@ -43,7 +44,7 @@ func envVar(key, value string) string {
 }
 
 func (c *dnsClient) createRecord(fqdn, value string, ttl int) error {
-	providerConfig, err := getDNSConfigFromSecret(c.secret, c.secretKey)
+	providerConfig, err := getDNSConfigFromSecret(c.secret, c.namespace, c.secretKey)
 	if err != nil {
 		return errors.New("Error getting dns config from secret" + err.Error())
 	}
@@ -72,7 +73,7 @@ func (c *dnsClient) createRecord(fqdn, value string, ttl int) error {
 }
 
 func (c *dnsClient) deleteRecord(fqdn, value string, ttl int) error {
-	providerConfig, err := getDNSConfigFromSecret(c.secret, c.secretKey)
+	providerConfig, err := getDNSConfigFromSecret(c.secret, c.namespace, c.secretKey)
 	if err != nil {
 		return errors.New("Error getting dns config from secret" + err.Error())
 	}

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -120,7 +120,7 @@ func monitorCertificateEvents() (<-chan CertificateEvent, <-chan error) {
 }
 
 func getDNSConfigFromSecret(name, namespace, key string) ([]byte, error) {
-	resp, err := http.Get(certificateEndpoint(namespace, name))
+	resp, err := http.Get(secretEndpoint(namespace, name))
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func getDNSConfigFromSecret(name, namespace, key string) ([]byte, error) {
 
 func deleteKubernetesSecret(c Certificate) error {
 
-	req, err := http.NewRequest("DELETE", certificateEndpoint(c.Metadata["namespace"], c.Spec.Domain), nil)
+	req, err := http.NewRequest("DELETE", secretEndpoint(c.Metadata["namespace"], c.Spec.Domain), nil)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func deleteKubernetesSecret(c Certificate) error {
 	return nil
 }
 
-func certificateEndpoint(namespace string, name string) string {
+func secretEndpoint(namespace string, name string) string {
 	return apiHost + "/api/v1/namespaces/" + namespace + "/secrets/" + name
 }
 
@@ -178,7 +178,7 @@ func syncKubernetesSecret(requested Certificate, cert, key []byte) error {
 		Metadata:   metadata,
 		Type:       "kubernetes.io/tls",
 	}
-	endPoint := certificateEndpoint(requested.Metadata["namespace"], requested.Spec.Domain)
+	endPoint := secretEndpoint(requested.Metadata["namespace"], requested.Spec.Domain)
 	fmt.Println("Secret endpoint is: " + endPoint)
 	resp, err := http.Get(endPoint)
 	if err != nil {

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -179,7 +179,6 @@ func syncKubernetesSecret(requested Certificate, cert, key []byte) error {
 		Type:       "kubernetes.io/tls",
 	}
 	endPoint := secretEndpoint(requested.Metadata["namespace"], requested.Spec.Domain)
-	fmt.Println("Secret endpoint is: " + endPoint)
 	resp, err := http.Get(endPoint)
 	if err != nil {
 		return err

--- a/processor.go
+++ b/processor.go
@@ -108,7 +108,7 @@ func deleteCertificate(c Certificate, db *bolt.DB) error {
 		return errors.New("Error deleting the Let's Encrypt account " + err.Error())
 	}
 	log.Printf("Deleting Kubernetes TLS secret: %s", c.Spec.Domain)
-	return deleteKubernetesSecret(c.Spec.Domain)
+	return deleteKubernetesSecret(c)
 }
 
 func processCertificate(c Certificate, db *bolt.DB) error {
@@ -158,7 +158,7 @@ func processCertificate(c Certificate, db *bolt.DB) error {
 			Headers: nil,
 			Bytes:   x509.MarshalPKCS1PrivateKey(account.CertificateKey),
 		})
-		err = syncKubernetesSecret(c.Spec.Domain, account.Certificate, key)
+		err = syncKubernetesSecret(c, account.Certificate, key)
 		if err != nil {
 			return errors.New("Error creating Kubernetes secret: " + err.Error())
 		}
@@ -178,6 +178,7 @@ func processCertificate(c Certificate, db *bolt.DB) error {
 		c.Spec.Provider,
 		c.Spec.Secret,
 		c.Spec.SecretKey,
+		c.Metadata["namespace"],
 	}
 
 	// Cleaning up the DNS challenge here creates a race between two processes
@@ -216,7 +217,7 @@ func processCertificate(c Certificate, db *bolt.DB) error {
 		Headers: nil,
 		Bytes:   x509.MarshalPKCS1PrivateKey(account.CertificateKey),
 	})
-	err = syncKubernetesSecret(c.Spec.Domain, account.Certificate, key)
+	err = syncKubernetesSecret(c, account.Certificate, key)
 	if err != nil {
 		return errors.New("Error creating Kubernetes secret: " + err.Error())
 	}


### PR DESCRIPTION
This pull request allows the cert manager to use namespaces, instead of just assuming everything is in default.

The cert manager will now listen for certificate requests in all namespaces, and assumes the provider secret and the certificate secret will be in that same namespace.
