### PR TITLE
[certbundle] Add root certificate to the certificate chain

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	certExpiry = 365 * 12 * time.Hour
-	certBundle = false
+	certBundle = true
 )
 
 var (


### PR DESCRIPTION
This PR adds the entire cert bundle into the certificate chain. Without this in place, if you use golang to interact with a service using a generated certificate being served with the nginx ingress controller with the default configuration, you'll get x509 errors. 

This also moves the SSL Labs report card for from B to A+ using the above configuration.
