### PR TITLE
Fix to work with subdomains and domains

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -104,11 +104,23 @@ func (c *dnsClient) monitorDNSPropagation(fqdn, value string, ttl int) error {
 	dnsClient := new(dns.Client)
 	dnsClient.Net = "tcp"
 	dnsClient.Timeout = time.Second * 10
+	delimiter := "."
+	domainSplited := strings.Split(c.domain, delimiter)
 
-	ns, err := net.LookupNS(c.domain)
-	if err != nil {
-		return err
+	var ns []*net.NS
+
+	for i := range domainSplited {
+		var err error
+		domain := strings.Join((domainSplited)[i:], delimiter)
+		ns, err = net.LookupNS(domain)
+		if err == nil {
+			break
+		} else {
+			log.Println("No NS found for:", domain)
+			log.Println(err)
+		}
 	}
+
 	nameservers := make([]string, 0)
 	for _, s := range ns {
 		nameservers = append(nameservers, net.JoinHostPort(s.Host, "53"))

--- a/dns.go
+++ b/dns.go
@@ -24,8 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/publicsuffix"
-
 	"github.com/miekg/dns"
 )
 
@@ -107,11 +105,7 @@ func (c *dnsClient) monitorDNSPropagation(fqdn, value string, ttl int) error {
 	dnsClient.Net = "tcp"
 	dnsClient.Timeout = time.Second * 10
 
-	suffix, err := publicsuffix.EffectiveTLDPlusOne(strings.TrimSuffix(fqdn, "."))
-	if err != nil {
-		return err
-	}
-	ns, err := net.LookupNS(dns.Fqdn(suffix))
+	ns, err := net.LookupNS(c.domain)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fix #21 

The old PR #14 always verify the TLD, so if you have a domain within your TLD it won't verify the right NS servers.

This PR iterate over the requested name for certs until it finds the NS.

Example:
sub2.sub1.domain.com it tried to get the NS for sub2.sub1.domain.com  it fails it goes to sub1.domain.com and so on. There is no checks for invalid entries.
If sub1 has different NS than domain it will watch the sub1 NS for changes.

